### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Enables the communication with devices that use the Serial Peripheral Interface (SPI) Bus. For all Arduino boards, BUT Arduino DUE. 
 paragraph=
+category=Communication
 url=http://arduino.cc/en/Reference/SPI
 architectures=esp8266


### PR DESCRIPTION
Lack of a category field in library.properties causes the warning:
```
WARNING: Category '' in library SPI is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format