### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,23 +6,23 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-SPIesp  	KEYWORD1
-SPI     	KEYWORD1
+SPIesp	KEYWORD1
+SPI	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin	 KEYWORD2
-end		 KEYWORD2
-spi_txd	 KEYWORD2
-spi_txd	 KEYWORD2
-transfer KEYWORD2
-spi_tx8	 KEYWORD2
-spi_tx16 KEYWORD2
-spi_tx32 KEYWORD2
+begin	KEYWORD2
+end	KEYWORD2
+spi_txd	KEYWORD2
+spi_txd	KEYWORD2
+transfer	KEYWORD2
+spi_tx8	KEYWORD2
+spi_tx16	KEYWORD2
+spi_tx32	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-SSPI LITERAL1
-HSPI LITERAL1
+SSPI	LITERAL1
+HSPI	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords